### PR TITLE
Update notebooks

### DIFF
--- a/parallelization.ipynb
+++ b/parallelization.ipynb
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ipcluster start -n 4 --daemon\n",
+    "!ipcluster start -n 4 --daemonize\n",
     "\n",
     "# This is here just to ensure that ipcluster has enough time to start properly before continuing\n",
     "import time\n",
@@ -424,7 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d2 = elfi.Distance('cityblock', model['S1'], model['S2'], p=1)\n",
+    "d2 = elfi.Distance('cityblock', model['S1'], model['S2'])\n",
     "\n",
     "rej2 = elfi.Rejection(d2, batch_size=10000)\n",
     "result2 = rej2.sample(1000, quantile=0.01)"

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "First ensure you have [installed](http://elfi.readthedocs.io/en/stable/installation.html) Python 3.5 (or greater) and ELFI. After installation you can start using ELFI:"
+    "First ensure you have [installed](http://elfi.readthedocs.io/en/stable/installation.html) Python 3.7 (or greater) and ELFI. After installation you can start using ELFI:"
    ]
   },
   {


### PR DESCRIPTION
#### Summary:

updated the minimum python version in quickstart notebook and fixed the ipyparallel and cityblock distance options in parallelisation notebook

#### Intended Effect:

- minimum python version (3.7) matches the version in ELFI README
- it is possible to run the parallelisation notebook

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
